### PR TITLE
Change SIGKILL to SIGHUP

### DIFF
--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -36,7 +36,7 @@ class ServerFactory
         $loop->addSignal(SIGTERM, function (int $signal) {
             exit(128 + $signal);
         });
-        $loop->addSignal(SIGKILL, function (int $signal) {
+        $loop->addSignal(SIGHUP, function (int $signal) {
             exit(128 + $signal);
         });
         $server = new HttpServer($loop, function (ServerRequestInterface $request) use ($requestHandler) {


### PR DESCRIPTION
Fix for error:
> Fatal error: Error installing signal handler for 9 in /app/vendor/react/event-loop/src/StreamSelectLoop.php on line 161 

From https://www.php.net/manual/en/function.pcntl-signal.php#83981 (14 years ago): 
> You cannot assign a signal handler for SIGKILL (kill -9).